### PR TITLE
Feature slack manager questions display

### DIFF
--- a/controllers/reports.js
+++ b/controllers/reports.js
@@ -107,8 +107,7 @@ router.post("/", adminValidation, async (req, res) => {
   const newReport = { ...req.body, teamId };
 
   try {
-    const report = await Reports.add(newReport);
-    console.log("report", report);
+    await Reports.add(newReport);
     const reports = await Reports.findByTeam(teamId);
     res.status(201).json(reports);
   } catch (error) {

--- a/helpers/slack.js
+++ b/helpers/slack.js
@@ -199,12 +199,14 @@ const button = async reports => {
 function combine(arr1, arr2) {
   let result = [];
   for (let i = 0; i < arr1.length; i++) {
-    result.push("*");
-    result.push(arr1[i]);
-    result.push("*");
-    result.push("\n");
-    result.push(arr2[i]);
-    result.push("\n");
+    if (arr2[i].length) {
+      result.push("*");
+      result.push(arr1[i]);
+      result.push("*");
+      result.push("\n");
+      result.push(arr2[i]);
+      result.push("\n");
+    }
   }
   return result;
 }

--- a/helpers/slack.js
+++ b/helpers/slack.js
@@ -1,60 +1,214 @@
-const axios = require("axios");
-
 const url = "https://slack.com/api/im.open";
 const postUrl = "https://slack.com/api/chat.postMessage";
-
 const headers = {
   "Content-type": "application/json; charset=utf-8",
   Authorization: `Bearer ${process.env.SLACK_ACCESS_TOKEN}`
 };
+const axios = require("axios");
 
+//Steps for sending out reports
+
+// Array of reports to be sent out
+// Loop over reports array, for each report find all users
+// Slack - For each user send out button
+// Web - for each user send out email
+
+// this component is the message we send to slack with a respond button
+// ex. Hi, Ben :wave: Please fill out your report!    Respond
+//
 const button = async reports => {
   try {
     reports.map(async report => {
       report.users.map(async user => {
-        const message = {
-          user: user.slackUserId,
-          include_locale: true,
-          return_im: true
-        };
-
-        const { data } = await axios.post(url, message, { headers });
-
-        const response = {
-          channel: data.channel.id,
-          attachments: [
-            {
-              blocks: [
+        let response = {};
+        let result = "";
+        let managerQuestions = JSON.parse(report.managerQuestions);
+        let managerResponses = JSON.parse(report.managerResponses);
+        if (report.isSentiment) {
+          try {
+            const message = {
+              user: user.slackUserId,
+              include_locale: true,
+              return_im: true
+            };
+            const { data } = await axios.post(url, message, { headers });
+            response = {
+              // the response is the message that's being sent to slack.
+              channel: data.channel.id,
+              attachments: [
                 {
-                  type: "section",
-                  text: {
-                    type: "plain_text",
-                    text: `Please fill out your report: ${report.reportName}`
-                  },
-                  accessory: {
-                    type: "button",
-                    text: {
-                      type: "plain_text",
-                      text: "Button",
-                      emoji: true
+                  blocks: [
+                    {
+                      type: "section",
+                      text: {
+                        type: "mrkdwn",
+                        text: `Hi ${user.fullName} :wave:`
+                      }
                     },
-                    value: JSON.stringify(report)
-                  }
+                    {
+                      type: "divider"
+                    },
+                    {
+                      type: "section",
+                      text: {
+                        type: "mrkdwn",
+                        text: `Please fill out your report: ${
+                          report.reportName
+                        }`
+                      },
+                      accessory: {
+                        type: "button",
+                        text: {
+                          type: "plain_text",
+                          text: "Respond",
+                          emoji: true
+                        },
+                        value: JSON.stringify(report)
+                      }
+                    }
+                  ]
                 }
               ]
+            };
+          } catch (err) {
+            throw new Error("invalid or incomplete sentiment report inputs");
+          }
+        } else {
+          try {
+            // combine manager questions with responses to send into slack
+            const message = {
+              user: user.slackUserId,
+              include_locale: true,
+              return_im: true
+            };
+            const { data } = await axios.post(url, message, { headers });
+            if (managerResponses.length) {
+              const combinedArr = combine(managerQuestions, managerResponses);
+              result = combinedArr.join("");
+              response = {
+                // the response is the message that's being sent to slack.
+                channel: data.channel.id,
+                attachments: [
+                  {
+                    blocks: [
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: `Hi ${user.fullName} :wave:`
+                        }
+                      },
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: `Here is your manager's Goal for the week!`
+                        }
+                      },
+                      {
+                        type: "divider"
+                      },
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: result
+                        }
+                      },
+                      {
+                        type: "divider"
+                      },
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: `Please fill out your report: ${
+                            report.reportName
+                          }`
+                        },
+                        accessory: {
+                          type: "button",
+                          text: {
+                            type: "plain_text",
+                            text: "Respond",
+                            emoji: true
+                          },
+                          value: JSON.stringify(report)
+                        }
+                      }
+                    ]
+                  }
+                ]
+              };
+            } else {
+              response = {
+                // the response is the message that's being sent to slack.
+                channel: data.channel.id,
+                attachments: [
+                  {
+                    blocks: [
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: `Hi ${user.fullName} :wave:`
+                        }
+                      },
+                      {
+                        type: "divider"
+                      },
+                      {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: `Please fill out your report: ${
+                            report.reportName
+                          }`
+                        },
+                        accessory: {
+                          type: "button",
+                          text: {
+                            type: "plain_text",
+                            text: "Respond",
+                            emoji: true
+                          },
+                          value: JSON.stringify(report)
+                        }
+                      }
+                    ]
+                  }
+                ]
+              };
             }
-          ]
-        };
+          } catch (err) {
+            throw new Error("please include managers responses");
+          }
+        }
         const responseMessage = await axios.post(postUrl, response, {
           headers
         });
+        // console.log("response from slack", responseMessage);
       });
     });
   } catch (err) {
-    console.log(err);
+    //sentry call
+    throw new Error(err);
   }
 };
 
-// module.exports = {
-// 	button
-// };
+function combine(arr1, arr2) {
+  let result = [];
+  for (let i = 0; i < arr1.length; i++) {
+    result.push("*");
+    result.push(arr1[i]);
+    result.push("*");
+    result.push("\n");
+    result.push(arr2[i]);
+    result.push("\n");
+  }
+  return result;
+}
+
+module.exports = {
+  button
+};

--- a/helpers/slackReports.js
+++ b/helpers/slackReports.js
@@ -82,11 +82,8 @@ const slackReports = async () => {
         return newReport;
       })
     );
-    console.log(stitchedReports);
     //Call the slack button function
-    console.log("button not sent");
     const but = await button(stitchedReports);
-    console.log("button sent", but);
 
     return "The function has successfully ran";
   } catch (error) {

--- a/helpers/slackReports.js
+++ b/helpers/slackReports.js
@@ -2,8 +2,7 @@ const Reports = require("../models/Reports");
 const getDay = require("date-fns/get_day");
 const getHours = require("date-fns/get_hours");
 const getMinutes = require("date-fns/get_minutes");
-const axios = require("axios");
-
+const { button } = require("./slack");
 const Users = require("../models/Users");
 
 const daysToNumbers = {
@@ -83,9 +82,11 @@ const slackReports = async () => {
         return newReport;
       })
     );
-
+    console.log(stitchedReports);
     //Call the slack button function
-    await button(stitchedReports);
+    console.log("button not sent");
+    const but = await button(stitchedReports);
+    console.log("button sent", but);
 
     return "The function has successfully ran";
   } catch (error) {
@@ -97,113 +98,3 @@ const slackReports = async () => {
 module.exports = {
   slackReports
 };
-
-//Steps for sending out reports
-
-// Array of reports to be sent out
-// Loop over reports array, for each report find all users
-// Slack - For each user send out button
-// Web - for each user send out email
-
-const url = "https://slack.com/api/im.open";
-const postUrl = "https://slack.com/api/chat.postMessage";
-const headers = {
-  "Content-type": "application/json; charset=utf-8",
-  Authorization: `Bearer ${process.env.SLACK_ACCESS_TOKEN}`
-};
-// this component is the message we send to slack with a respond button
-// ex. Hi, Ben :wave: Please fill out your report!    Respond
-//
-const button = async reports => {
-  try {
-    reports.map(async report => {
-      report.users.map(async user => {
-        // combine manager questions with responses to send into slack
-        let managerQuestions = JSON.parse(report.managerQuestions);
-        let managerResponses = JSON.parse(report.managerResponses);
-        const combinedArr = combine(managerQuestions, managerResponses);
-        let result = combinedArr.join("");
-
-        const message = {
-          user: user.slackUserId,
-          include_locale: true,
-          return_im: true
-        };
-        const { data } = await axios.post(url, message, { headers });
-        // used to get the id of the channel
-        const response = {
-          // the response is the message that's being sent to slack.
-          channel: data.channel.id,
-          attachments: [
-            {
-              blocks: [
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: `Hi ${user.fullName} :wave:`
-                  }
-                },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: `Here is your manager's Goal for the week!`
-                  }
-                },
-                {
-                  type: "divider"
-                },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: `${result}`
-                  }
-                },
-                {
-                  type: "divider"
-                },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: `Please fill out your report: ${report.reportName}`
-                  },
-                  accessory: {
-                    type: "button",
-                    text: {
-                      type: "plain_text",
-                      text: "Respond",
-                      emoji: true
-                    },
-                    value: JSON.stringify(report)
-                  }
-                }
-              ]
-            }
-          ]
-        };
-        const responseMessage = await axios.post(postUrl, response, {
-          headers
-        });
-      });
-    });
-  } catch (err) {
-    //sentry call
-    throw new Error(err);
-  }
-};
-
-function combine(arr1, arr2) {
-  let result = [];
-  for (let i = 0; i < arr1.length; i++) {
-    result.push("*");
-    result.push(arr1[i]);
-    result.push("*");
-    result.push("\n");
-    result.push(arr2[i]);
-    result.push("\n");
-  }
-  return result;
-}


### PR DESCRIPTION
# Description

Slack now correctly receives stand up reports and sentiment reports.
If the manager responses are not included, it will omit the manager questions.
If the manager responses are supplied, it will include the manager questions.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Change status
- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
